### PR TITLE
Create library.json for PlatformIO

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,27 @@
+{
+  "name": "RokkitHash",
+  "keywords": "hash, superfasthash, hsieh, rokkit, sukkopera",
+  "description": "Arduino port of Paul Hsieh's 'SuperFastHash'. A very quick hash function, see http://www.azillionmonkeys.com/qed/hash.html for more information about its inner workings.",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/SukkoPera/Arduino-Rokkit-Hash.git"
+  },
+  "version": "20151212",
+  "authors": [
+    {
+      "name": "SukkoPera",
+      "email": "software@sukkology.net",
+      "url": "http://www.sukkology.net/blog/",
+      "maintainer": true
+    },
+    {
+      "name": "Rob Tillaart"
+    },
+    {
+      "name": "Alex K"
+    }
+  ],
+  "frameworks": "arduino",
+  "platforms": "*"
+}


### PR DESCRIPTION
I thought it would be useful to have this library available through the [PlatformIO Libraries Registry](http://platformio.org/lib) so I went ahead and added a `library.json` file for this purpose. If you want to merge it, the library can then be registered from the command line as follows: 

`platformio lib register https://github.com/SukkoPera/Arduino-Rokkit-Hash/blob/master/library.json`

See http://docs.platformio.org/en/latest/userguide/lib/cmd_register.html for details.
