### PR TITLE
Disable ROKKIT_ENABLE_FLASH_FUNCTIONS by default

### DIFF
--- a/src/RokkitHash.h
+++ b/src/RokkitHash.h
@@ -40,7 +40,7 @@
 #include <inttypes.h>
 
 #define ROKKIT_ENABLE_8BIT_OPTIMIZATIONS
-#define ROKKIT_ENABLE_FLASH_FUNCTIONS
+//~ #define ROKKIT_ENABLE_FLASH_FUNCTIONS
 
 uint32_t rokkit (const char *data, uint16_t len);
 


### PR DESCRIPTION
Avoid linker error on platformio, complaining file avr/progmem.h does not exist, using arduino-esp32 (= non avr platform).